### PR TITLE
Issue 374: Fabric APIs with Schema 2020.3 are not working from ODIM

### DIFF
--- a/lib-dmtf/model/Chassis.go
+++ b/lib-dmtf/model/Chassis.go
@@ -133,7 +133,7 @@ type Status struct {
 	Health       string `json:"Health,omitempty"`
 	HealthRollup string `json:"HealthRollup,omitempty"`
 	State        string `json:"State,omitempty"`
-	Oem          Oem    `json:"Oem,omitempty"`
+	Oem          *Oem   `json:"Oem,omitempty"`
 }
 
 // Thermal redfish structure

--- a/lib-dmtf/model/ComputerSystem.go
+++ b/lib-dmtf/model/ComputerSystem.go
@@ -446,7 +446,7 @@ type PCIeInterface struct {
 	PCIeType    string `json:"PCIeType"` //enum
 }
 
-/* 
+/*
 PCIeFunction 1.2.2
 This resource shall be used to represent a PCIeFunction attached to a System.
 URIs:

--- a/lib-dmtf/model/Links.go
+++ b/lib-dmtf/model/Links.go
@@ -16,10 +16,13 @@ package model
 
 // Links - this is Common to all resources
 type Links struct {
+	AddressPools             []Link `json:"AddressPools,omitempty"`
 	Chassis                  []Link `json:"Chassis,omitempty"`
 	ComputerSystems          []Link `json:"ComputerSystems,omitempty"`
+	ConnectedPorts           []Link `json:"ConnectedPorts,omitempty"`
 	ConsumingComputerSystems []Link `json:"ConsumingComputerSystems,omitempty"`
 	ContainedBy              []Link `json:"ContainedBy,omitempty"`
+	ContainedByZones         []Link `json:"ContainedByZones,omitempty"`
 	CooledBy                 []Link `json:"CooledBy,omitempty"`
 	Endpoints                []Link `json:"Endpoints,omitempty"`
 	EndpointsCount           int    `json:"Endpoints@odata.count,omitempty"`

--- a/lib-dmtf/model/Links.go
+++ b/lib-dmtf/model/Links.go
@@ -16,24 +16,27 @@ package model
 
 // Links - this is Common to all resources
 type Links struct {
-	Chassis                  []Link `json:",omitempty"`
-	ComputerSystems          []Link `json:",omitempty"`
-	ConsumingComputerSystems []Link `json:",omitempty"`
-	ContainedBy              []Link `json:",omitempty"`
-	CooledBy                 []Link `json:",omitempty"`
-	Endpoints                []Link `json:",omitempty"`
-	Drives                   []Link `json:",omitempty"`
-	ManagedBy                []Link `json:",omitempty"`
-	Oem                      *Oem   `json:",omitempty"`
-	ManagersInChassis        []Link `json:",omitempty"`
-	PCIeDevices              []Link `json:",omitempty"`
-	PCIeFunctions            []Link `json:",omitempty"`
-	PoweredBy                []Link `json:",omitempty"`
-	Processors               []Link `json:",omitempty"`
-	ResourceBlocks           []Link `json:",omitempty"`
-	Storage                  []Link `json:",omitempty"`
-	SupplyingComputerSystems []Link `json:",omitempty"`
-	Switches                 []Link `json:",omitempty"`
+	Chassis                  []Link `json:"Chassis,omitempty"`
+	ComputerSystems          []Link `json:"ComputerSystems,omitempty"`
+	ConsumingComputerSystems []Link `json:"ConsumingComputerSystems,omitempty"`
+	ContainedBy              []Link `json:"ContainedBy,omitempty"`
+	CooledBy                 []Link `json:"CooledBy,omitempty"`
+	Endpoints                []Link `json:"Endpoints,omitempty"`
+	EndpointsCount           int    `json:"Endpoints@odata.count,omitempty"`
+	Drives                   []Link `json:"Drives,omitempty"`
+	ManagedBy                []Link `json:"ManagedBy,omitempty"`
+	Oem                      *Oem   `json:"Oem,omitempty"`
+	ManagersInChassis        []Link `json:"ManagersInChassis,omitempty"`
+	PCIeDevices              []Link `json:"PCIeDevices,omitempty"`
+	PCIeFunctions            []Link `json:"PCIeFunctions,omitempty"`
+	PoweredBy                []Link `json:"PoweredBy,omitempty"`
+	Processors               []Link `json:"Processors,omitempty"`
+	ResourceBlocks           []Link `json:"ResourceBlocks,omitempty"`
+	Storage                  []Link `json:"Storage,omitempty"`
+	SupplyingComputerSystems []Link `json:"SupplyingComputerSystems,omitempty"`
+	Switches                 []Link `json:"Switches,omitempty"`
+	Zones                    []Link `json:"Zones,omitempty"`
+	ZonesCount               int    `json:"Zones@odata.count,omitempty"`
 }
 
 // Link holds the odata id redfish links

--- a/lib-dmtf/model/addressPool.go
+++ b/lib-dmtf/model/addressPool.go
@@ -44,6 +44,7 @@ type AddressPoolEthernet struct {
 	IPv4              *IPv4                `json:"IPv4,omitempty"`
 	MultiProtocolEBGP *EBGP                `json:"MultiProtocolEBGP,omitempty"`
 	MultiProtocolIBGP *CommonBGPProperties `json:"MultiProtocolIBGP,omitempty"`
+	SystemMACRange    *AddressRange        `json:"SystemMACRange,omitempty"`
 }
 
 // GenZ redfish model
@@ -68,20 +69,21 @@ type BFDSingleHopOnly struct {
 
 // BGPEvpn redfish structure
 type BGPEvpn struct {
-	ARPProxyEnabled                  bool         `json:"ARPProxyEnabled,omitempty"`
-	ARPSupressionEnabled             bool         `json:"ARPSupressionEnabled,omitempty"`
-	AnycastGatewayIPAddress          string       `json:"AnycastGatewayIPAddress,omitempty"`
-	AnycastGatewayMACAddress         string       `json:"AnycastGatewayMACAddress,omitempty"`
-	ESINumberRange                   *NumberRange `json:"ESINumberRange,omitempty"`
-	EVINumberRange                   *NumberRange `json:"EVINumberRange,omitempty"`
-	GatewayIPAddress                 string       `json:"GatewayIPAddress,omitempty"`
-	NDPProxyEnabled                  bool         `json:"NDPProxyEnabled,omitempty"`
-	NDPSupressionEnabled             bool         `json:"NDPSupressionEnabled,omitempty"`
-	RouteDistinguisherRange          *NumberRange `json:"RouteDistinguisherRange,omitempty"`
-	RouteTargetRange                 *NumberRange `json:"RouteTargetRange,omitempty"`
-	UnderlayMulticastEnabled         bool         `json:"UnderlayMulticastEnabled,omitempty"`
-	UnknownUnicastSuppressionEnabled bool         `json:"UnknownUnicastSuppressionEnabled,omitempty"`
-	VLANIdentifierAddressRange       *NumberRange `json:"VLANIdentifierAddressRange,omitempty"`
+	ARPProxyEnabled                  bool          `json:"ARPProxyEnabled,omitempty"`
+	ARPSupressionEnabled             bool          `json:"ARPSupressionEnabled,omitempty"`
+	AnycastGatewayIPAddress          string        `json:"AnycastGatewayIPAddress,omitempty"`
+	AnycastGatewayMACAddress         string        `json:"AnycastGatewayMACAddress,omitempty"`
+	ESINumberRange                   *NumberRange  `json:"ESINumberRange,omitempty"`
+	EVINumberRange                   *NumberRange  `json:"EVINumberRange,omitempty"`
+	GatewayIPAddress                 string        `json:"GatewayIPAddress,omitempty"`
+	GatewayIPAddressRange            *AddressRange `json:"GatewayIPAddressRange,omitempty"`
+	NDPProxyEnabled                  bool          `json:"NDPProxyEnabled,omitempty"`
+	NDPSupressionEnabled             bool          `json:"NDPSupressionEnabled,omitempty"`
+	RouteDistinguisherRange          *AddressRange `json:"RouteDistinguisherRange,omitempty"`
+	RouteTargetRange                 *AddressRange `json:"RouteTargetRange,omitempty"`
+	UnderlayMulticastEnabled         bool          `json:"UnderlayMulticastEnabled,omitempty"`
+	UnknownUnicastSuppressionEnabled bool          `json:"UnknownUnicastSuppressionEnabled,omitempty"`
+	VLANIdentifierAddressRange       *NumberRange  `json:"VLANIdentifierAddressRange,omitempty"`
 }
 
 // EBGP redfish structure

--- a/lib-dmtf/model/addressPool.go
+++ b/lib-dmtf/model/addressPool.go
@@ -27,7 +27,7 @@ type AddressPool struct {
 	Links        *Links               `json:"Links,omitempty"`
 	Name         string               `json:"Name"`
 	Oem          *Oem                 `json:"Oem,omitempty"`
-	Status       string               `json:"Status,omitempty"`
+	Status       *Status              `json:"Status,omitempty"`
 }
 
 // OemActions redfish model

--- a/lib-dmtf/model/addressPool.go
+++ b/lib-dmtf/model/addressPool.go
@@ -1,0 +1,205 @@
+//(C) Copyright [2020] Hewlett Packard Enterprise Development LP
+//
+//Licensed under the Apache License, Version 2.0 (the "License"); you may
+//not use this file except in compliance with the License. You may obtain
+//a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//License for the specific language governing permissions and limitations
+// under the License.
+
+package model
+
+// AddressPool is the redfish AddressPool model for 2020.3 release
+type AddressPool struct {
+	ODataContext string               `json:"@odata.context,omitempty"`
+	ODataEtag    string               `json:"@odata.etag,omitempty"`
+	ODataID      string               `json:"@odata.id"`
+	ODataType    string               `json:"@odata.type"`
+	Actions      *OemActions          `json:"Actions,omitempty"`
+	Ethernet     *AddressPoolEthernet `json:"Ethernet,omitempty"`
+	GenZ         *GenZ                `json:"GenZ,omitempty"`
+	ID           string               `json:"id"`
+	Links        *Links               `json:"Links,omitempty"`
+	Name         string               `json:"Name"`
+	Oem          *Oem                 `json:"Oem,omitempty"`
+	Status       string               `json:"Status,omitempty"`
+}
+
+// OemActions redfish model
+type OemActions struct {
+	Oem *Oem `json:"Oem,omitempty"`
+}
+
+// AddressPoolEthernet redfish model
+type AddressPoolEthernet struct {
+	BFDSingleHopOnly  *BFDSingleHopOnly    `json:"BFDSingleHopOnly,omitempty"`
+	BGPEvpn           *BGPEvpn             `json:"BGPEvpn,omitempty"`
+	EBGP              *EBGP                `json:"EBGP,omitempty"`
+	IPv4              *IPv4                `json:"IPv4,omitempty"`
+	MultiProtocolEBGP *EBGP                `json:"MultiProtocolEBGP,omitempty"`
+	MultiProtocolIBGP *CommonBGPProperties `json:"MultiProtocolIBGP,omitempty"`
+}
+
+// GenZ redfish model
+type GenZ struct {
+	AccessKey string `json:"AccessKey,omitempty"`
+	MaxCID    int    `json:"MaxCID,omitempty"`
+	MaxSID    int    `json:"MaxSID,omitempty"`
+	MinCID    int    `json:"MinCID,omitempty"`
+	MinSID    int    `json:"MinSID,omitempty"`
+}
+
+// BFDSingleHopOnly redfish structure
+type BFDSingleHopOnly struct {
+	DemandModeEnabled                 bool   `json:"DemandModeEnabled,omitempty"`
+	DesiredMinTxIntervalMilliseconds  int    `json:"DesiredMinTxIntervalMilliseconds,omitempty"`
+	KeyChain                          string `json:"KeyChain,omitempty"`
+	LocalMultiplier                   int    `json:"LocalMultiplier,omitempty"`
+	MeticulousModeEnabled             bool   `json:"MeticulousModeEnabled,omitempty"`
+	RequiredMinRxIntervalMilliseconds int    `json:"RequiredMinRxIntervalMilliseconds,omitempty"`
+	SourcePort                        int    `json:"SourcePort,omitempty"`
+}
+
+// BGPEvpn redfish structure
+type BGPEvpn struct {
+	ARPProxyEnabled                  bool         `json:"ARPProxyEnabled,omitempty"`
+	ARPSupressionEnabled             bool         `json:"ARPSupressionEnabled,omitempty"`
+	AnycastGatewayIPAddress          string       `json:"AnycastGatewayIPAddress,omitempty"`
+	AnycastGatewayMACAddress         string       `json:"AnycastGatewayMACAddress,omitempty"`
+	ESINumberRange                   *NumberRange `json:"ESINumberRange,omitempty"`
+	EVINumberRange                   *NumberRange `json:"EVINumberRange,omitempty"`
+	GatewayIPAddress                 string       `json:"GatewayIPAddress,omitempty"`
+	NDPProxyEnabled                  bool         `json:"NDPProxyEnabled,omitempty"`
+	NDPSupressionEnabled             bool         `json:"NDPSupressionEnabled,omitempty"`
+	RouteDistinguisherRange          *NumberRange `json:"RouteDistinguisherRange,omitempty"`
+	RouteTargetRange                 *NumberRange `json:"RouteTargetRange,omitempty"`
+	UnderlayMulticastEnabled         bool         `json:"UnderlayMulticastEnabled,omitempty"`
+	UnknownUnicastSuppressionEnabled bool         `json:"UnknownUnicastSuppressionEnabled,omitempty"`
+	VLANIdentifierAddressRange       *NumberRange `json:"VLANIdentifierAddressRange,omitempty"`
+}
+
+// EBGP redfish structure
+type EBGP struct {
+	AllowDuplicateASEnabled bool             `json:"AllowDuplicateASEnabled,omitempty"`
+	AllowOverrideASEnabled  bool             `json:"AllowOverrideASEnabled,omitempty"`
+	AlwaysCompareMEDEnabled bool             `json:"AlwaysCompareMEDEnabled,omitempty"`
+	ASNumberRange           *NumberRange     `json:"ASNumberRange,omitempty"`
+	BGPLocalPreference      int              `json:"BGPLocalPreference,omitempty"`
+	BGPNeighbor             *BGPNeighbor     `json:"BGPNeighbor,omitempty"`
+	BGPRoute                *BGPRoute        `json:"BGPRoute,omitempty"`
+	BGPWeight               int              `json:"BGPWeight,omitempty"`
+	GracefulRestart         *GracefulRestart `json:"GracefulRestart,omitempty"`
+	MED                     int              `json:"MED,omitempty"`
+	MultihopEnabled         bool             `json:"MultihopEnabled,omitempty"`
+	MultihopTTL             int              `json:"MultihopTTL,omitempty"`
+	MultiplePaths           *MultiplePaths   `json:"MultiplePaths,omitempty"`
+	SendCommunityEnabled    bool             `json:"SendCommunityEnabled,omitempty"`
+}
+
+// IPv4 redfish model
+type IPv4 struct {
+	AnycastGatewayIPAddress       string        `json:"AnycastGatewayIPAddress,omitempty"`
+	AnycastGatewayMACAddress      string        `json:"AnycastGatewayMACAddress,omitempty"`
+	DHCP                          *DHCP         `json:"DHCP,omitempty"`
+	DNSDomainName                 string        `json:"DNSDomainName,omitempty"`
+	DNSServer                     string        `json:"DNSServer,omitempty"`
+	DistributeIntoUnderlayEnabled bool          `json:"DistributeIntoUnderlayEnabled,omitempty"`
+	EBGPAddressRange              *AddressRange `json:"EBGPAddressRange,omitempty"`
+	FabricLinkAddressRange        *AddressRange `json:"FabricLinkAddressRange,omitempty"`
+	GatewayIPAddress              string        `json:"GatewayIPAddress,omitempty"`
+	HostAddressRange              *AddressRange `json:"HostAddressRange,omitempty"`
+	IBGPAddressRange              *AddressRange `json:"IBGPAddressRange,omitempty"`
+	LoopbackAddressRange          *AddressRange `json:"LoopbackAddressRange,omitempty"`
+	ManagementAddressRange        *AddressRange `json:"ManagementAddressRange,omitempty"`
+	NTPOffsetHoursMinutes         int           `json:"NTPOffsetHoursMinutes,omitempty"`
+	NTPServer                     string        `json:"NTPServer,omitempty"`
+	NTPTimezone                   string        `json:"NTPTimezone,omitempty"`
+	NativeVLAN                    string        `json:"NativeVLAN,omitempty"`
+	VLANIdentifierAddressRange    *NumberRange  `json:"VLANIdentifierAddressRange,omitempty"`
+}
+
+// CommonBGPProperties redfish model
+type CommonBGPProperties struct {
+	ASNumberRange        *NumberRange     `json:"ASNumberRange,omitempty"`
+	BGPNeighbor          *BGPNeighbor     `json:"BGPNeighbor,omitempty"`
+	BGPRoute             *BGPRoute        `json:"BGPRoute,omitempty"`
+	GracefulRestart      *GracefulRestart `json:"GracefulRestart,omitempty"`
+	MultiplePaths        *MultiplePaths   `json:"MultiplePaths,omitempty"`
+	SendCommunityEnabled bool             `json:"SendCommunityEnabled,omitempty"`
+}
+
+// NumberRange is a common structure ASNumberRange, ESINumberRange, EVINumberRange, etc
+type NumberRange struct {
+	Lower int `json:"Lower,omitempty"`
+	Upper int `json:"Upper,omitempty"`
+}
+
+// AddressRange is a common structure EBGPAddressRange, FabricLinkAddressRange, HostAddressRange, etc
+type AddressRange struct {
+	Lower string `json:"Lower,omitempty"`
+	Upper string `json:"Upper,omitempty"`
+}
+
+// BGPNeighbor redfish structure
+type BGPNeighbor struct {
+	Address                             string     `json:"Address,omitempty"`
+	AllowOwnASEnabled                   bool       `json:"AllowOwnASEnabled,omitempty"`
+	ConnectRetrySeconds                 int        `json:"ConnectRetrySeconds,omitempty"`
+	HoldTimeSeconds                     int        `json:"HoldTimeSeconds,omitempty"`
+	KeepaliveIntervalSeconds            int        `json:"KeepaliveIntervalSeconds,omitempty"`
+	LocalAS                             int        `json:"LocalAS,omitempty"`
+	LogStateChangesEnabled              bool       `json:"LogStateChangesEnabled,omitempty"`
+	MaxPrefix                           *MaxPrefix `json:"MaxPrefix,omitempty"`
+	MinimumAdvertisementIntervalSeconds int        `json:"MinimumAdvertisementIntervalSeconds,omitempty"`
+	PassiveModeEnabled                  bool       `json:"PassiveModeEnabled,omitempty"`
+	PathMTUDiscoveryEnabled             bool       `json:"PathMTUDiscoveryEnabled,omitempty"`
+	PeerAS                              int        `json:"PeerAS,omitempty"`
+	ReplacePeerASEnabled                bool       `json:"ReplacePeerASEnabled,omitempty"`
+	TCPMaxSegmentSizeBytes              int        `json:"TCPMaxSegmentSizeBytes,omitempty"`
+	TreatAsWithdrawEnabled              bool       `json:"TreatAsWithdrawEnabled,omitempty"`
+}
+
+// BGPRoute redfish model
+type BGPRoute struct {
+	AdvertiseInactiveRoutesEnabled bool `json:"AdvertiseInactiveRoutesEnabled,omitempty"`
+	DistanceExternal               int  `json:"DistanceExternal,omitempty"`
+	DistanceInternal               int  `json:"DistanceInternal,omitempty"`
+	DistanceLocal                  int  `json:"DistanceLocal,omitempty"`
+	ExternalCompareRouterIDEnabled bool `json:"ExternalCompareRouterIdEnabled,omitempty"`
+	FlapDampingEnabled             bool `json:"FlapDampingEnabled,omitempty"`
+	SendDefaultRouteEnabled        bool `json:"SendDefaultRouteEnabled,omitempty"`
+}
+
+// GracefulRestart redfish model
+type GracefulRestart struct {
+	GracefulRestartEnabled bool `json:"GracefulRestartEnabled,omitempty"`
+	HelperModeEnabled      bool `json:"HelperModeEnabled,omitempty"`
+	StaleRoutesTimeSeconds int  `json:"StaleRoutesTimeSeconds,omitempty"`
+	TimeSeconds            int  `json:"TimeSeconds,omitempty"`
+}
+
+// MultiplePaths redfish model
+type MultiplePaths struct {
+	MaximumPaths            int  `json:"MaximumPaths,omitempty"`
+	UseMultiplePathsEnabled bool `json:"UseMultiplePathsEnabled,omitempty"`
+}
+
+// MaxPrefix redfish model
+type MaxPrefix struct {
+	MaxPrefixNumber             int     `json:"MaxPrefixNumber,omitempty"`
+	RestartTimerSeconds         int     `json:"RestartTimerSeconds,omitempty"`
+	ShutdownThresholdPercentage float64 `json:"ShutdownThresholdPercentage,omitempty"`
+	ThresholdWarningOnlyEnabled bool    `json:"ThresholdWarningOnlyEnabled,omitempty"`
+}
+
+// DHCP redfish model
+type DHCP struct {
+	DHCPInterfaceMTUBytes int    `json:"DHCPInterfaceMTUBytes,omitempty"`
+	DHCPRelayEnabled      bool   `json:"DHCPRelayEnabled,omitempty"`
+	DHCPServer            string `json:"DHCPServer,omitempty"`
+}

--- a/lib-dmtf/model/addressPool.go
+++ b/lib-dmtf/model/addressPool.go
@@ -14,7 +14,7 @@
 
 package model
 
-// AddressPool is the redfish AddressPool model for 2020.3 release
+// AddressPool is the redfish AddressPool model according to the 2020.3 release
 type AddressPool struct {
 	ODataContext string               `json:"@odata.context,omitempty"`
 	ODataEtag    string               `json:"@odata.etag,omitempty"`

--- a/lib-dmtf/model/addressPool.go
+++ b/lib-dmtf/model/addressPool.go
@@ -21,6 +21,7 @@ type AddressPool struct {
 	ODataID      string               `json:"@odata.id"`
 	ODataType    string               `json:"@odata.type"`
 	Actions      *OemActions          `json:"Actions,omitempty"`
+	Description  string               `json:"Description,omitempty"`
 	Ethernet     *AddressPoolEthernet `json:"Ethernet,omitempty"`
 	GenZ         *GenZ                `json:"GenZ,omitempty"`
 	ID           string               `json:"id"`

--- a/svc-fabrics/fabrics/common.go
+++ b/svc-fabrics/fabrics/common.go
@@ -81,45 +81,54 @@ type OdataID struct {
 	OdataID string `json:"@odata.id"`
 }
 
+// TODO: The implementation of the AddressPools model is incorrect.
+// We will be replacing this with the AddressPool model available
+// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
+
 // AddressPools struct to check request body cases
 type AddressPools struct {
 	Name        string  `json:"Name"`
 	Description string  `json:"Description"`
 	IPv4        IPv4    `json:"IPv4"`
-	Ebgp        Ebgp    `json:"Ebgp"`
-	BgpEvpn     BgpEvpn `json:"BgpEvpn"`
+	Ebgp        Ebgp    `json:"EBGP"`
+	BgpEvpn     BgpEvpn `json:"BGPEvpn"`
 }
+
+// TODO: The implementation of the IPv4 model is incorrect.
+// We will be replacing this with the IPv4 model available
+// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
 
 // IPv4 struct to check request body cases in AddressPools
 type IPv4 struct {
-	VlanIdentifierAddressRange AddressRangeInt    `json:"VlanIdentifierAddressRange"`
-	IbgpAddressRange           AddressRangeString `json:"IbgpAddressRange"`
-	EbgpAddressRange           AddressRangeString `json:"EbgpAddressRange"`
+	VlanIdentifierAddressRange *dmtf.NumberRange  `json:"VLANIdentifierAddressRange"`
+	IbgpAddressRange           *dmtf.AddressRange `json:"IBGPAddressRange"`
+	EbgpAddressRange           *dmtf.AddressRange `json:"EBGPAddressRange"`
+	NativeVLAN                 int                `json:"NativeVLAN"`
 }
 
-//AddressRangeString struct to check request body cases
-type AddressRangeString struct {
-	Lower string `json:"Lower"`
-	Upper string `json:"Upper"`
-}
-
-//AddressRangeInt struct to check request body cases
-type AddressRangeInt struct {
-	Lower int `json:"Lower"`
-	Upper int `json:"Upper"`
-}
+// TODO: The implementation of the Ebgp model is incorrect.
+// We will be replacing this with the EBGP model available
+// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
 
 //Ebgp struct to check request body cases
 type Ebgp struct {
-	AsNumberRange AddressRangeInt `json:"AsNumberRange"`
+	AsNumberRange *dmtf.NumberRange `json:"AsNumberRange"`
 }
+
+// TODO: The implementation of the BgpEvpn model is incorrect.
+// We will be replacing this with the BGPEvpn model available
+// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
 
 //BgpEvpn struct to check request body cases
 type BgpEvpn struct {
-	GatewayIPAddressList    []string `json:"GatewayIPAddressList"`
-	RouteDistinguisherList  []string `json:"RouteDistinguisherList"`
-	RouteTargetList         []string `json:"RouteTargetList"`
-	AnycastGatewayIPAddress string   `json:"AnycastGatewayIPAddress"`
+	GatewayIPAddressList    []string           `json:"GatewayIPAddressList"`
+	RouteDistinguisherList  []string           `json:"RouteDistinguisherList"`
+	RouteTargetList         []string           `json:"RouteTargetList"`
+	AnycastGatewayIPAddress string             `json:"AnycastGatewayIPAddress"`
+	GatewayIPAddressRange   *dmtf.AddressRange `json:"GatewayIPAddressRange"`
+	RouteDistinguisherRange *dmtf.AddressRange `json:"RouteDistinguisherRange"`
+	RouteTargetRange        *dmtf.AddressRange `json:"RouteTargetRange"`
+	EVINumberRange          *dmtf.NumberRange  `json:"EVINumberRange"`
 }
 
 //Endpoints struct to check request body cases
@@ -469,6 +478,9 @@ func validateReqParamsCase(req *fabricsproto.FabricRequest) (response.RPC, error
 	if strings.Contains(req.URL, "/Zones") {
 		fabricRequest = &Zones{}
 	} else if strings.Contains(req.URL, "/AddressPools") {
+		// TODO: The implementation of the AddressPools model is incorrect.
+		// We will be replacing this with the AddressPool model available
+		// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
 		fabricRequest = &AddressPools{}
 	} else if strings.Contains(req.URL, "/Endpoints") {
 		fabricRequest = &Endpoints{}

--- a/svc-fabrics/fabrics/common.go
+++ b/svc-fabrics/fabrics/common.go
@@ -63,72 +63,9 @@ type PluginToken struct {
 
 // Zones struct to check request body cases
 type Zones struct {
-	Name     string `json:"Name"`
-	ZoneType string `json:"ZoneType"`
-	Links    Links  `json:"Links"`
-}
-
-// Links struct to check request body cases in Zones
-type Links struct {
-	AddressPools     []OdataID `json:"AddressPools"`
-	ContainedByZones []OdataID `json:"ContainedByZones"`
-	Endpoints        []OdataID `json:"Endpoints"`
-	ConnectedPorts   []OdataID `json:"ConnectedPorts"`
-}
-
-// OdataID struct to check request body cases
-type OdataID struct {
-	OdataID string `json:"@odata.id"`
-}
-
-// TODO: The implementation of the AddressPools model is incorrect.
-// We will be replacing this with the AddressPool model available
-// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
-
-// AddressPools struct to check request body cases
-type AddressPools struct {
-	Name        string  `json:"Name"`
-	Description string  `json:"Description"`
-	IPv4        IPv4    `json:"IPv4"`
-	Ebgp        Ebgp    `json:"EBGP"`
-	BgpEvpn     BgpEvpn `json:"BGPEvpn"`
-}
-
-// TODO: The implementation of the IPv4 model is incorrect.
-// We will be replacing this with the IPv4 model available
-// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
-
-// IPv4 struct to check request body cases in AddressPools
-type IPv4 struct {
-	VlanIdentifierAddressRange *dmtf.NumberRange  `json:"VLANIdentifierAddressRange"`
-	IbgpAddressRange           *dmtf.AddressRange `json:"IBGPAddressRange"`
-	EbgpAddressRange           *dmtf.AddressRange `json:"EBGPAddressRange"`
-	NativeVLAN                 int                `json:"NativeVLAN"`
-}
-
-// TODO: The implementation of the Ebgp model is incorrect.
-// We will be replacing this with the EBGP model available
-// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
-
-//Ebgp struct to check request body cases
-type Ebgp struct {
-	AsNumberRange *dmtf.NumberRange `json:"AsNumberRange"`
-}
-
-// TODO: The implementation of the BgpEvpn model is incorrect.
-// We will be replacing this with the BGPEvpn model available
-// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
-
-//BgpEvpn struct to check request body cases
-type BgpEvpn struct {
-	GatewayIPAddressList    []string           `json:"GatewayIPAddressList"`
-	RouteDistinguisherList  []string           `json:"RouteDistinguisherList"`
-	RouteTargetList         []string           `json:"RouteTargetList"`
-	AnycastGatewayIPAddress string             `json:"AnycastGatewayIPAddress"`
-	GatewayIPAddressRange   *dmtf.AddressRange `json:"GatewayIPAddressRange"`
-	RouteDistinguisherRange *dmtf.AddressRange `json:"RouteDistinguisherRange"`
-	RouteTargetRange        *dmtf.AddressRange `json:"RouteTargetRange"`
-	EVINumberRange          *dmtf.NumberRange  `json:"EVINumberRange"`
+	Name     string     `json:"Name"`
+	ZoneType string     `json:"ZoneType"`
+	Links    dmtf.Links `json:"Links"`
 }
 
 //Endpoints struct to check request body cases
@@ -136,13 +73,13 @@ type Endpoints struct {
 	Name        string       `json:"Name"`
 	Description string       `json:"Description"`
 	Redundancy  []Redundancy `json:"Redundancy"`
-	Links       Links        `json:"Links"`
+	Links       dmtf.Links   `json:"Links"`
 }
 
 //Redundancy struct to check request body cases
 type Redundancy struct {
-	Mode          string    `json:"Mode"`
-	RedundencySet []OdataID `json:"RedundencySet"`
+	Mode          string      `json:"Mode"`
+	RedundencySet []dmtf.Link `json:"RedundencySet"`
 }
 
 // Token variable hold the all the XAuthToken  against the plguin ID
@@ -478,10 +415,7 @@ func validateReqParamsCase(req *fabricsproto.FabricRequest) (response.RPC, error
 	if strings.Contains(req.URL, "/Zones") {
 		fabricRequest = &Zones{}
 	} else if strings.Contains(req.URL, "/AddressPools") {
-		// TODO: The implementation of the AddressPools model is incorrect.
-		// We will be replacing this with the AddressPool model available
-		// in lib-dmtf as soon as the fabric plugin is ready to accomadate it.
-		fabricRequest = &AddressPools{}
+		fabricRequest = &dmtf.AddressPool{}
 	} else if strings.Contains(req.URL, "/Endpoints") {
 		fabricRequest = &Endpoints{}
 	}

--- a/svc-fabrics/go.mod
+++ b/svc-fabrics/go.mod
@@ -3,7 +3,7 @@ module github.com/ODIM-Project/ODIM/svc-fabrics
 go 1.13
 
 require (
-	github.com/ODIM-Project/ODIM/lib-dmtf v0.0.0-20210129210848-1246a6839cd8
+	github.com/ODIM-Project/ODIM/lib-dmtf v0.0.0-20210201115703-c080c23df61e
 	github.com/ODIM-Project/ODIM/lib-rest-client v0.0.0-20201201072448-9772421f1b55
 	github.com/ODIM-Project/ODIM/lib-utilities v0.0.0-20201201072448-9772421f1b55
 	github.com/sirupsen/logrus v1.4.2

--- a/svc-fabrics/go.mod
+++ b/svc-fabrics/go.mod
@@ -3,7 +3,7 @@ module github.com/ODIM-Project/ODIM/svc-fabrics
 go 1.13
 
 require (
-	github.com/ODIM-Project/ODIM/lib-dmtf v0.0.0-20201201072448-9772421f1b55
+	github.com/ODIM-Project/ODIM/lib-dmtf v0.0.0-20210129210848-1246a6839cd8
 	github.com/ODIM-Project/ODIM/lib-rest-client v0.0.0-20201201072448-9772421f1b55
 	github.com/ODIM-Project/ODIM/lib-utilities v0.0.0-20201201072448-9772421f1b55
 	github.com/sirupsen/logrus v1.4.2

--- a/svc-fabrics/go.sum
+++ b/svc-fabrics/go.sum
@@ -264,6 +264,7 @@ github.com/klauspost/compress v1.10.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/kolo/xmlrpc v0.0.0-20190717152603-07c4ee3fd181/go.mod h1:o03bZfuBwAXHetKXuInt4S7omeXUu62/A845kiycsSQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
The PR contains:
- Added new model for AddressPool to lib-dmtf
- Modifying existing AdderssPool implementation in svc-fabrics to work along with fabric plugin
- Added TODO messages indicating that the models in svc-fabrics will be soon replaced with the lib-dmtf once fabric plugin is ready.

Fix for #374