### PR TITLE
Issue 522: Change the data type of lib-dmtf Oem for accommodating any data

### DIFF
--- a/lib-dmtf/model/Links.go
+++ b/lib-dmtf/model/Links.go
@@ -48,5 +48,4 @@ type Link struct {
 }
 
 // Oem holds the vendor specific details which is addtional to redfish contents
-type Oem struct {
-}
+type Oem interface {}

--- a/lib-dmtf/model/Links.go
+++ b/lib-dmtf/model/Links.go
@@ -48,4 +48,4 @@ type Link struct {
 }
 
 // Oem holds the vendor specific details which is addtional to redfish contents
-type Oem interface {}
+type Oem interface{}


### PR DESCRIPTION
In this PR:

Changed the data type of Oem in lib-dmtf to interface.